### PR TITLE
Remove empty keyword string to prevent warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "reddit",
     "API",
     "wrapper",
-    "redwrap",
-    ""
+    "redwrap"
   ],
   "author": "Stephen Whatley",
   "license": "MIT",


### PR DESCRIPTION
empty string in `keywords` array gives the warning

    npm WARN package.json redwrap@0.0.4 keywords should be an array of strings