### PR TITLE
Added options flag (debug) to requester for console.log

### DIFF
--- a/requester.js
+++ b/requester.js
@@ -13,7 +13,10 @@ var request = require('request')
 
 /*==========  CONSTRUCTOR  ==========*/
 
-var Requester = function(path) {
+var Requester = function(path, options) {
+                options = options || {};
+                this.debug = options.debug || false;
+
 		this.ee = new EventEmitter();
 		this.path = path || '/';
 		this.filter = '';
@@ -73,7 +76,9 @@ Requester.prototype.collector = function() {
 	,	nextAfter = ''
 	,	prevAfter = '';
 
-	console.log('Requesting: ' + reqUrl);
+	if (that.debug) {
+		console.log('Requesting: ' + reqUrl);
+	}
 
 	request.get(reqUrl, function(error, res, body){
 		if (error) {


### PR DESCRIPTION
By default, the requester was outputting to the terminal via console.log. For some use cases I personally have, as I'm sure others will as well, this should be optional as not to clutter the output. Added an options object with defaults to console requests when debug:true.